### PR TITLE
Move @types/geojson to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.2",
     "@rapideditor/country-coder": "^5.6.1",
+    "@types/geojson": "^7946.0.16",
     "circle-to-polygon": "^2.2.0",
     "geojson-precision": "^1.0.0",
     "json-stringify-pretty-compact": "^4.0.0",
@@ -56,7 +57,6 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/bun": "^1.3.12",
-    "@types/geojson": "^7946.0.16",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
The public API exports `LocoFeature` and `LocoFeatureCollection`, which extend `GeoJSON.Feature` and `GeoJSON.FeatureCollection` from `@types/geojson`. TypeScript consumers need the `GeoJSON` namespace available at compile time, so `@types/geojson` must be a regular dependency (not `devDependencies`) to ensure it's installed transitively.